### PR TITLE
Update link to CLA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,4 @@
 <!-- Make sure to read and accept the CLA, before you open the pull request: `CONTRIBUTOR_LICENSE_AGREEMENT` -->
 <!-- Tick the checkbox in case you accept it (`[x]`) -->
 
-- [ ] I have read and accept the
-  [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)
+- [ ] I have read and accept the [Contributor License Agreement](https://opensource.porsche.com/docs/cla)


### PR DESCRIPTION
In order to have one single source of truth, we want to remove all duplicates of the Contributor License Agreement and update all references to point towards https://opensource.porsche.com/docs/cla.

- [X] I have read and accept the
  [Contributor License Agreement](https://github.com/porscheofficial/oss-docs/blob/67c5b24838a293ce7a964884e6005eb71f2b8579/CONTRIBUTOR_LICENSE_AGREEMENT.md)
